### PR TITLE
Adds slash as an allowed character for formatted CNPJs

### DIFF
--- a/Source/CPF-CNPJ-Validator.swift
+++ b/Source/CPF-CNPJ-Validator.swift
@@ -96,7 +96,7 @@ fileprivate extension Validator {
         guard !options.contains(.interpretOnlyNumbers) else { return true }
 
         let characters = string.map { String($0) }
-        let allowedCharacterSet = CharacterSet(charactersIn: "0123456789-.")
+        let allowedCharacterSet = CharacterSet(charactersIn: "0123456789-./")
         let charactersRemovingAllowedCharacters = characters.filter {
             $0.rangeOfCharacter(from: allowedCharacterSet) == nil
         }


### PR DESCRIPTION
Allows CNPJs formatted like 00.000.000/0000-00 to pass the test.